### PR TITLE
feat: add dummy k8s resource so deploys work

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  PLACEHOLDER: placeholder
+kind: ConfigMap
+metadata:
+  labels:
+    app: fortress
+  name: fortress-environment
+  namespace: default

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  PLACEHOLDER: placeholder
+kind: ConfigMap
+metadata:
+  labels:
+    app: fortress
+  name: fortress-environment
+  namespace: default


### PR DESCRIPTION
[main](https://app.circleci.com/pipelines/github/artsy/fortress/5/workflows/4a0d0bed-50c8-4546-b2d7-efeb3aba1db5/jobs/13?invite=true#step-105-229_33) build failed due to empty spec.

Let's add a dummy configmap resource for each env.